### PR TITLE
typo fix: wrong repo name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ This repository implements the [quickstart](http://docs.microsoft.com/azure/stor
 First, clone the repository on your machine:
 
 ```bash
-git clone https://github.com/Azure-Samples/azure-storage-blob-js.git
+git clone https://github.com/Azure-Samples/azure-storage-js-v10-quickstart.git
 ```
 
 Then, switch to the appropriate folder:
 
 ```bash
-cd azure-storage-blob-js
+cd azure-storage-js-v10-quickstart
 ```
 
 Next, install the dependencies:


### PR DESCRIPTION
Wrong repo name in README.md file

## Purpose
* fix the typo in repo names in **`git clone`** and **`cd`** commands in the README.md file

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## Other Information
**Existing:**
`git clone https://github.com/Azure-Samples/azure-storage-blob-js.git`
**To be changed as:**
`git clone https://github.com/Azure-Samples/azure-storage-js-v10-quickstart.git`
**Existing:**
`cd azure-storage-blob-js`
**To be changed as:**
`cd azure-storage-js-v10-quickstart`